### PR TITLE
Copy DLLs to the same directory as the executable that needs them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.21)
 project(CMakeSFMLProject LANGUAGES CXX)
 
 include(FetchContent)
@@ -10,5 +10,9 @@ FetchContent_MakeAvailable(SFML)
 add_executable(CMakeSFMLProject src/main.cpp)
 target_link_libraries(CMakeSFMLProject PRIVATE sfml-graphics)
 target_compile_features(CMakeSFMLProject PRIVATE cxx_std_17)
+if (WIN32 AND BUILD_SHARED_LIBS)
+    add_custom_command(TARGET CMakeSFMLProject POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:CMakeSFMLProject> $<TARGET_FILE_DIR:CMakeSFMLProject> COMMAND_EXPAND_LISTS)
+endif()
 
 install(TARGETS CMakeSFMLProject)


### PR DESCRIPTION
This bumps our CMake requirement to 3.21 which means Ubuntu 20 users cannot use this anymore without manually updating CMake even though they don't need this DLL copying code.

I copied some of this pattern from SFML's [`sfml_add_test`](https://github.com/SFML/SFML/blob/e1f36e66a53ff526d566c0e95bb3082a1c8b194c/cmake/Macros.cmake#L350-L358).